### PR TITLE
Simplify handlers by removing `Maybe` return value

### DIFF
--- a/examples/ace/src/Container.purs
+++ b/examples/ace/src/Container.purs
@@ -2,7 +2,6 @@ module Example.Ace.Container where
 
 import Prelude
 
-import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 import Effect.Aff.Class (class MonadAff)
 import Example.Ace.AceComponent as AceComponent
@@ -45,12 +44,12 @@ render { text: text } =
     , HH.div_
         [ HH.p_
             [ HH.button
-                [ HE.onClick \_ -> Just ClearText ]
+                [ HE.onClick \_ -> ClearText ]
                 [ HH.text "Clear" ]
             ]
         ]
     , HH.div_
-        [ HH.slot _ace unit AceComponent.component unit (Just <<< HandleAceUpdate) ]
+        [ HH.slot _ace unit AceComponent.component unit HandleAceUpdate ]
     , HH.p_
         [ HH.text ("Current text: " <> text) ]
     ]

--- a/examples/basic/src/Button.purs
+++ b/examples/basic/src/Button.purs
@@ -2,7 +2,6 @@ module Example.Basic.Button (component) where
 
 import Prelude
 
-import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -30,7 +29,7 @@ render state =
   in
     HH.button
       [ HP.title label
-      , HE.onClick \_ -> Just Toggle
+      , HE.onClick \_ -> Toggle
       ]
       [ HH.text label ]
 

--- a/examples/components-inputs/src/Container.purs
+++ b/examples/components-inputs/src/Container.purs
@@ -2,7 +2,6 @@ module Example.Components.Inputs.Container where
 
 import Prelude
 
-import Data.Maybe (Maybe(..))
 import Data.Symbol (SProxy(..))
 import Example.Components.Inputs.Display as Display
 import Halogen as H
@@ -43,10 +42,10 @@ render state =
         , HH.slot _display 5 Display.component (state * state) absurd
         ]
     , HH.button
-        [ HE.onClick (\_ -> Just Increment) ]
+        [ HE.onClick \_ -> Increment ]
         [ HH.text "+1"]
     , HH.button
-        [ HE.onClick (\_ -> Just Decrement) ]
+        [ HE.onClick \_ -> Decrement ]
         [ HH.text "-1"]
     ]
 

--- a/examples/components-multitype/src/ComponentA.purs
+++ b/examples/components-multitype/src/ComponentA.purs
@@ -35,7 +35,7 @@ render state =
   HH.div_
     [ HH.p_ [ HH.text "Toggle me!" ]
     , HH.button
-        [ HE.onClick \_ -> Just Toggle ]
+        [ HE.onClick \_ -> Toggle ]
         [ HH.text (if state then "On" else "Off") ]
     ]
 

--- a/examples/components-multitype/src/ComponentB.purs
+++ b/examples/components-multitype/src/ComponentB.purs
@@ -38,7 +38,7 @@ render state =
         , HH.strong_ [ HH.text (show state) ]
         ]
     , HH.button
-        [ HE.onClick \_ -> Just Increment ]
+        [ HE.onClick \_ -> Increment ]
         [ HH.text ("Increment") ]
     ]
 

--- a/examples/components-multitype/src/ComponentC.purs
+++ b/examples/components-multitype/src/ComponentC.purs
@@ -37,7 +37,7 @@ render state =
     [ HH.p_ [ HH.text "What do you have to say?" ]
     , HH.input
         [ HP.value state
-        , HE.onValueInput (Just <<< HandleInput)
+        , HE.onValueInput HandleInput
         ]
     ]
 

--- a/examples/components-multitype/src/Container.purs
+++ b/examples/components-multitype/src/Container.purs
@@ -66,7 +66,7 @@ render state = HH.div_
       , HH.li_ [ HH.text ("Component C: " <> show state.c) ]
       ]
   , HH.button
-      [ HE.onClick (\_ -> Just ReadStates) ]
+      [ HE.onClick \_ -> ReadStates ]
       [ HH.text "Check states now" ]
   ]
 

--- a/examples/components/src/Button.purs
+++ b/examples/components/src/Button.purs
@@ -39,7 +39,7 @@ render state =
   in
     HH.button
       [ HP.title label
-      , HE.onClick \_ -> Just Toggle
+      , HE.onClick \_ -> Toggle
       ]
       [ HH.text label ]
 

--- a/examples/components/src/Container.purs
+++ b/examples/components/src/Container.purs
@@ -42,7 +42,7 @@ initialState _ =
 render :: forall m. State -> H.ComponentHTML Action ChildSlots m
 render state =
   HH.div_
-    [ HH.slot _button unit Button.component unit (Just <<< HandleButton)
+    [ HH.slot _button unit Button.component unit HandleButton
     , HH.p_
         [ HH.text ("Button has been toggled " <> show state.toggleCount <> " time(s)") ]
     , HH.p_
@@ -51,7 +51,7 @@ render state =
             <> (maybe "(not checked yet)" (if _ then "on" else "off") state.buttonState)
             <> ". "
         , HH.button
-            [ HE.onClick (\_ -> Just CheckButtonState) ]
+            [ HE.onClick \_ -> CheckButtonState ]
             [ HH.text "Check now" ]
         ]
     ]

--- a/examples/driver-io/src/Button.purs
+++ b/examples/driver-io/src/Button.purs
@@ -41,7 +41,7 @@ render state =
   in
     HH.button
       [ HP.title label
-      , HE.onClick \_ -> Just Toggle
+      , HE.onClick \_ -> Toggle
       ]
       [ HH.text label ]
 

--- a/examples/driver-websockets/src/Log.purs
+++ b/examples/driver-websockets/src/Log.purs
@@ -44,12 +44,12 @@ initialState _ = { messages: [] , inputText: "" }
 render :: forall m. State -> H.ComponentHTML Action () m
 render state =
   HH.form
-    [ HE.onSubmit (Just <<< Submit) ]
+    [ HE.onSubmit Submit ]
     [ HH.ol_ $ map (\msg -> HH.li_ [ HH.text msg ]) state.messages
     , HH.input
         [ HP.type_ HP.InputText
         , HP.value (state.inputText)
-        , HE.onValueInput (Just <<< HandleInput)
+        , HE.onValueInput HandleInput
         ]
     , HH.button
         [ HP.type_ HP.ButtonSubmit ]

--- a/examples/effects-aff-ajax/src/Component.purs
+++ b/examples/effects-aff-ajax/src/Component.purs
@@ -38,13 +38,13 @@ initialState _ = { loading: false, username: "", result: Nothing }
 render :: forall m. State -> H.ComponentHTML Action () m
 render st =
   HH.form
-    [ HE.onSubmit (Just <<< MakeRequest) ]
+    [ HE.onSubmit MakeRequest ]
     [ HH.h1_ [ HH.text "Lookup GitHub user" ]
     , HH.label_
         [ HH.div_ [ HH.text "Enter username:" ]
         , HH.input
             [ HP.value st.username
-            , HE.onValueInput (Just <<< SetUsername)
+            , HE.onValueInput SetUsername
             ]
         ]
     , HH.button

--- a/examples/effects-eff-random/src/Component.purs
+++ b/examples/effects-eff-random/src/Component.purs
@@ -33,7 +33,7 @@ render state =
       [ HH.h1_ [ HH.text "Random number" ]
       , HH.p_ [ HH.text ("Current value: " <> value) ]
       , HH.button
-          [ HE.onClick \_ -> Just Regenerate ]
+          [ HE.onClick \_ -> Regenerate ]
           [ HH.text "Generate new number" ]
       ]
 

--- a/examples/higher-order-components/src/Button.purs
+++ b/examples/higher-order-components/src/Button.purs
@@ -39,7 +39,7 @@ render state =
   in
     HH.button
       [ HP.title label
-      , HE.onClick \_ -> Just Toggle
+      , HE.onClick \_ -> Toggle
       ]
       [ HH.text label ]
 

--- a/examples/higher-order-components/src/Harness.purs
+++ b/examples/higher-order-components/src/Harness.purs
@@ -40,10 +40,10 @@ initialState _ = { buttonCheckState: Nothing, buttonMessageState: Nothing }
 render :: forall m. State -> H.ComponentHTML Action ChildSlots m
 render state =
   HH.div_
-    [ HH.slot _panel unit panelComponent unit (Just <<< HandlePanelMessage)
+    [ HH.slot _panel unit panelComponent unit HandlePanelMessage
     , HH.div_
         [ HH.button
-            [ HE.onClick \_ -> Just CheckButtonState ]
+            [ HE.onClick \_ -> CheckButtonState ]
             [ HH.text "Check button state" ]
         , HH.p_
             [ HH.text ("Last result: " <> printButtonState state.buttonCheckState) ]

--- a/examples/higher-order-components/src/Panel.purs
+++ b/examples/higher-order-components/src/Panel.purs
@@ -66,13 +66,13 @@ render innerComponent state
             [ HP.classes [ H.ClassName "Panel-header" ] ]
             [ HH.button
                 [ HP.classes [ H.ClassName "Panel-toggleButton" ]
-                , HE.onClick \_ -> Just Toggle
+                , HE.onClick \_ -> Toggle
                 ]
                 [ HH.text "Close" ]
             ]
         , HH.div
             [ HP.classes [ H.ClassName "Panel-content" ] ]
-            [ HH.slot _inner unit innerComponent state.input (Just <<< HandleInner) ]
+            [ HH.slot _inner unit innerComponent state.input HandleInner ]
         ]
   | otherwise =
       HH.div
@@ -81,7 +81,7 @@ render innerComponent state
             [ HP.classes [ H.ClassName "Panel-header" ] ]
             [ HH.button
                 [ HP.classes [ H.ClassName "Panel-toggleButton" ]
-                , HE.onClick \_ -> Just Toggle
+                , HE.onClick \_ -> Toggle
                 ]
                 [ HH.text "Open" ]
             ]

--- a/examples/interpret/src/Main.purs
+++ b/examples/interpret/src/Main.purs
@@ -40,7 +40,7 @@ ui =
       [ HH.h1_
           [ HH.text "Fetch user data" ]
       , HH.button
-          [ HE.onClick \_ -> Just FetchData ]
+          [ HE.onClick \_ -> FetchData ]
           [ HH.text "Fetch" ]
       , HH.p_
           [ HH.text (fromMaybe "No user data" state.userData) ]

--- a/examples/lifecycle/src/Child.purs
+++ b/examples/lifecycle/src/Child.purs
@@ -45,10 +45,10 @@ child initialState =
     HH.div_
       [ HH.text ("Child " <> show id)
       , HH.ul_
-        [ HH.slot _cell 0 (cell 0) unit (listen 0)
-        , HH.slot _cell 1 (cell 1) unit (listen 1)
-        , HH.slot _cell 2 (cell 2) unit (listen 2)
-        ]
+          [ HH.slot _cell 0 (cell 0) unit (listen 0)
+          , HH.slot _cell 1 (cell 1) unit (listen 1)
+          , HH.slot _cell 2 (cell 2) unit (listen 2)
+          ]
       ]
 
   handleAction :: Action -> H.HalogenM Int Action ChildSlots Message Aff Unit
@@ -65,8 +65,8 @@ child initialState =
     H.liftEffect $ log $ "Child " <> show id <> " >>> " <> msg
     H.raise (Reported msg)
 
-  listen :: Int -> Message -> Maybe Action
-  listen i = Just <<< case _ of
+  listen :: Int -> Message -> Action
+  listen i = case _ of
     Initialized -> Report ("Heard Initialized from cell" <> show i)
     Finalized -> Report ("Heard Finalized from cell" <> show i)
     Reported msg -> Report ("Re-reporting from cell" <> show i <> ": " <> msg)

--- a/examples/lifecycle/src/Main.purs
+++ b/examples/lifecycle/src/Main.purs
@@ -59,16 +59,16 @@ ui =
   render state =
     HH.div_
       [ HH.button
-          [ HE.onClick \_ -> Just Add ]
+          [ HE.onClick \_ -> Add ]
           [ HH.text "Add" ]
       , HH.button
-          [ HE.onClick \_ -> Just Reverse ]
+          [ HE.onClick \_ -> Reverse ]
           [ HH.text "Reverse" ]
       , HK.ul_ $ flip map state.slots \sid ->
           Tuple (show sid) $
             HH.li_
               [ HH.button
-                  [ HE.onClick \_ -> Just (Remove sid) ]
+                  [ HE.onClick \_ -> Remove sid ]
                   [ HH.text "Remove" ]
               , HH.slot _child sid (Child.child sid) unit (listen sid)
               ]
@@ -91,8 +91,8 @@ ui =
   handleAction (ReportRoot msg) =
     H.liftEffect $ log ("Root >>> " <> msg)
 
-  listen :: Int -> Child.Message -> Maybe Action
-  listen i = Just <<< case _ of
+  listen :: Int -> Child.Message -> Action
+  listen i = case _ of
     Child.Initialized -> ReportRoot ("Heard Initialized from child" <> show i)
     Child.Finalized -> ReportRoot ("Heard Finalized from child" <> show i)
     Child.Reported msg -> ReportRoot ("Re-reporting from child" <> show i <> ": " <> msg)

--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -14,7 +14,7 @@ module Halogen.HTML
 import Halogen.HTML.Elements
 
 import Data.Function.Uncurried as Fn
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe(..))
 import Data.Symbol (class IsSymbol, SProxy)
 import Halogen.Component (Component, ComponentSlot(..), componentSlot)
 import Halogen.Data.Slot (Slot)
@@ -22,7 +22,7 @@ import Halogen.HTML.Core (class IsProp, AttrName(..), ClassName(..), HTML(..), N
 import Halogen.HTML.Core as Core
 import Halogen.HTML.Properties (IProp, attr, attrNS, prop)
 import Halogen.VDom.Thunk (thunk1, thunk2, thunk3, thunked)
-import Prelude (class Ord, Void)
+import Prelude (class Ord, Void, (<<<))
 import Prim.Row as Row
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -57,10 +57,10 @@ slot
   -> slot
   -> Component query input output m
   -> input
-  -> (output -> Maybe action)
+  -> (output -> action)
   -> ComponentHTML action slots m
 slot label p component input outputQuery =
-  Core.widget (ComponentSlot (componentSlot label p component input outputQuery))
+  Core.widget (ComponentSlot (componentSlot label p component input (Just <<< outputQuery)))
 
 -- | Optimizes rendering of a subtree given an equality predicate. If an argument
 -- | is deemed equivalent to the previous value, rendering and diffing will be

--- a/src/Halogen/HTML/Events.purs
+++ b/src/Halogen/HTML/Events.purs
@@ -82,194 +82,201 @@ import Web.UIEvent.MouseEvent.EventTypes as MET
 import Web.UIEvent.WheelEvent (WheelEvent)
 import Web.UIEvent.WheelEvent.EventTypes as WET
 
-handler :: forall r i. EventType -> (Event -> Maybe i) -> IProp r i
-handler et = (unsafeCoerce :: (EventType -> (Event -> Maybe i) -> Prop i) -> EventType -> (Event -> Maybe (Input i)) -> IProp r i) Core.handler et <<< map (map Action)
+handler :: forall r i. EventType -> (Event -> i) -> IProp r i
+handler et f =
+  (unsafeCoerce :: (EventType -> (Event -> Maybe i) -> Prop i) -> EventType -> (Event -> Maybe (Input i)) -> IProp r i)
+    Core.handler et \ev -> Just (Action (f ev))
 
-onAbort :: forall r i. (Event -> Maybe i) -> IProp (onAbort :: Event | r) i
+handler' :: forall r i. EventType -> (Event -> Maybe i) -> IProp r i
+handler' et f =
+  (unsafeCoerce :: (EventType -> (Event -> Maybe i) -> Prop i) -> EventType -> (Event -> Maybe (Input i)) -> IProp r i)
+    Core.handler et \ev -> Action <$> f ev
+
+onAbort :: forall r i. (Event -> i) -> IProp (onAbort :: Event | r) i
 onAbort = handler (EventType "abort")
 
-onError :: forall r i. (Event -> Maybe i) -> IProp (onError :: Event | r) i
+onError :: forall r i. (Event -> i) -> IProp (onError :: Event | r) i
 onError = handler ET.error
 
-onLoad :: forall r i. (Event -> Maybe i) -> IProp (onLoad :: Event | r) i
+onLoad :: forall r i. (Event -> i) -> IProp (onLoad :: Event | r) i
 onLoad = handler ET.load
 
-onScroll :: forall r i. (Event -> Maybe i) -> IProp (onScroll :: Event | r) i
+onScroll :: forall r i. (Event -> i) -> IProp (onScroll :: Event | r) i
 onScroll = handler (EventType "scroll")
 
-onChange :: forall r i. (Event -> Maybe i) -> IProp (onChange :: Event | r) i
+onChange :: forall r i. (Event -> i) -> IProp (onChange :: Event | r) i
 onChange = handler ET.change
 
-onInput :: forall r i. (Event -> Maybe i) -> IProp (onInput :: Event | r) i
+onInput :: forall r i. (Event -> i) -> IProp (onInput :: Event | r) i
 onInput = handler ET.input
 
-onInvalid :: forall r i. (Event -> Maybe i) -> IProp (onInvalid :: Event | r) i
+onInvalid :: forall r i. (Event -> i) -> IProp (onInvalid :: Event | r) i
 onInvalid = handler ET.invalid
 
-onReset :: forall r i. (Event -> Maybe i) -> IProp (onReset :: Event | r) i
+onReset :: forall r i. (Event -> i) -> IProp (onReset :: Event | r) i
 onReset = handler (EventType "reset")
 
-onSelect :: forall r i. (Event -> Maybe i) -> IProp (onSelect :: Event | r) i
+onSelect :: forall r i. (Event -> i) -> IProp (onSelect :: Event | r) i
 onSelect = handler ET.select
 
-onSubmit :: forall r i. (Event -> Maybe i) -> IProp (onSubmit :: Event | r) i
+onSubmit :: forall r i. (Event -> i) -> IProp (onSubmit :: Event | r) i
 onSubmit = handler (EventType "submit")
 
-onTransitionEnd :: forall r i. (Event -> Maybe i) -> IProp (onTransitionEnd :: Event | r) i
+onTransitionEnd :: forall r i. (Event -> i) -> IProp (onTransitionEnd :: Event | r) i
 onTransitionEnd = handler (EventType "transitionend")
 
-onCopy :: forall r i. (ClipboardEvent -> Maybe i) -> IProp (onCopy :: ClipboardEvent | r) i
+onCopy :: forall r i. (ClipboardEvent -> i) -> IProp (onCopy :: ClipboardEvent | r) i
 onCopy = handler CET.copy <<< clipboardHandler
 
-onPaste :: forall r i. (ClipboardEvent -> Maybe i) -> IProp (onPaste :: ClipboardEvent | r) i
+onPaste :: forall r i. (ClipboardEvent -> i) -> IProp (onPaste :: ClipboardEvent | r) i
 onPaste = handler CET.paste <<< clipboardHandler
 
-onCut :: forall r i. (ClipboardEvent -> Maybe i) -> IProp (onCut :: ClipboardEvent | r) i
+onCut :: forall r i. (ClipboardEvent -> i) -> IProp (onCut :: ClipboardEvent | r) i
 onCut = handler CET.cut <<< clipboardHandler
 
-onClick :: forall r i. (MouseEvent -> Maybe i) -> IProp (onClick :: MouseEvent | r) i
+onClick :: forall r i. (MouseEvent -> i) -> IProp (onClick :: MouseEvent | r) i
 onClick = handler MET.click <<< mouseHandler
 
--- onContextMenu :: forall r i. (MouseEvent -> Maybe i) -> IProp (onContextMenu :: MouseEvent | r) i
+-- onContextMenu :: forall r i. (MouseEvent -> i) -> IProp (onContextMenu :: MouseEvent | r) i
 -- onContextMenu = handler ET.contextmenu <<< mouseHandler
 
-onDoubleClick :: forall r i. (MouseEvent -> Maybe i) -> IProp (onDoubleClick :: MouseEvent | r) i
+onDoubleClick :: forall r i. (MouseEvent -> i) -> IProp (onDoubleClick :: MouseEvent | r) i
 onDoubleClick = handler MET.dblclick <<< mouseHandler
 
-onMouseDown :: forall r i. (MouseEvent -> Maybe i) -> IProp (onMouseDown :: MouseEvent | r) i
+onMouseDown :: forall r i. (MouseEvent -> i) -> IProp (onMouseDown :: MouseEvent | r) i
 onMouseDown = handler MET.mousedown <<< mouseHandler
 
-onMouseEnter :: forall r i. (MouseEvent -> Maybe i) -> IProp (onMouseEnter :: MouseEvent | r) i
+onMouseEnter :: forall r i. (MouseEvent -> i) -> IProp (onMouseEnter :: MouseEvent | r) i
 onMouseEnter = handler MET.mouseenter <<< mouseHandler
 
-onMouseLeave :: forall r i. (MouseEvent -> Maybe i) -> IProp (onMouseLeave :: MouseEvent | r) i
+onMouseLeave :: forall r i. (MouseEvent -> i) -> IProp (onMouseLeave :: MouseEvent | r) i
 onMouseLeave = handler MET.mouseleave <<< mouseHandler
 
-onMouseMove :: forall r i. (MouseEvent -> Maybe i) -> IProp (onMouseMove :: MouseEvent | r) i
+onMouseMove :: forall r i. (MouseEvent -> i) -> IProp (onMouseMove :: MouseEvent | r) i
 onMouseMove = handler MET.mousemove <<< mouseHandler
 
-onMouseOver :: forall r i. (MouseEvent -> Maybe i) -> IProp (onMouseOver :: MouseEvent | r) i
+onMouseOver :: forall r i. (MouseEvent -> i) -> IProp (onMouseOver :: MouseEvent | r) i
 onMouseOver = handler MET.mouseover <<< mouseHandler
 
-onMouseOut :: forall r i. (MouseEvent -> Maybe i) -> IProp (onMouseOut :: MouseEvent | r) i
+onMouseOut :: forall r i. (MouseEvent -> i) -> IProp (onMouseOut :: MouseEvent | r) i
 onMouseOut = handler MET.mouseout <<< mouseHandler
 
-onMouseUp :: forall r i. (MouseEvent -> Maybe i) -> IProp (onMouseUp :: MouseEvent | r) i
+onMouseUp :: forall r i. (MouseEvent -> i) -> IProp (onMouseUp :: MouseEvent | r) i
 onMouseUp = handler MET.mouseup <<< mouseHandler
 
-onWheel :: forall r i. (WheelEvent -> Maybe i) -> IProp (onWheel :: WheelEvent | r) i
+onWheel :: forall r i. (WheelEvent -> i) -> IProp (onWheel :: WheelEvent | r) i
 onWheel = handler WET.wheel <<< wheelHandler
 
-onKeyDown :: forall r i. (KeyboardEvent -> Maybe i) -> IProp (onKeyDown :: KeyboardEvent | r) i
+onKeyDown :: forall r i. (KeyboardEvent -> i) -> IProp (onKeyDown :: KeyboardEvent | r) i
 onKeyDown = handler KET.keydown <<< keyHandler
 
--- onKeyPress :: forall r i. (KeyboardEvent -> Maybe i) -> IProp (onKeyPress :: KeyboardEvent | r) i
+-- onKeyPress :: forall r i. (KeyboardEvent -> i) -> IProp (onKeyPress :: KeyboardEvent | r) i
 -- onKeyPress = handler KET.keypress <<< keyHandler
 
-onKeyUp :: forall r i. (KeyboardEvent -> Maybe i) -> IProp (onKeyUp :: KeyboardEvent | r) i
+onKeyUp :: forall r i. (KeyboardEvent -> i) -> IProp (onKeyUp :: KeyboardEvent | r) i
 onKeyUp = handler KET.keyup <<< keyHandler
 
-onBlur :: forall r i. (FocusEvent -> Maybe i) -> IProp (onBlur :: FocusEvent | r) i
+onBlur :: forall r i. (FocusEvent -> i) -> IProp (onBlur :: FocusEvent | r) i
 onBlur = handler ET.blur <<< focusHandler
 
-onFocus :: forall r i. (FocusEvent -> Maybe i) -> IProp (onFocus :: FocusEvent | r) i
+onFocus :: forall r i. (FocusEvent -> i) -> IProp (onFocus :: FocusEvent | r) i
 onFocus = handler FET.focus <<< focusHandler
 
-onFocusIn :: forall r i. (FocusEvent -> Maybe i) -> IProp (onFocusIn :: FocusEvent | r) i
+onFocusIn :: forall r i. (FocusEvent -> i) -> IProp (onFocusIn :: FocusEvent | r) i
 onFocusIn = handler FET.focusin <<< focusHandler
 
-onFocusOut :: forall r i. (FocusEvent -> Maybe i) -> IProp (onFocusOut :: FocusEvent | r) i
+onFocusOut :: forall r i. (FocusEvent -> i) -> IProp (onFocusOut :: FocusEvent | r) i
 onFocusOut = handler FET.focusout <<< focusHandler
 
-onDrag :: forall r i. (DragEvent -> Maybe i) -> IProp (onDrag :: DragEvent | r) i
+onDrag :: forall r i. (DragEvent -> i) -> IProp (onDrag :: DragEvent | r) i
 onDrag = handler DET.drag <<< dragHandler
 
-onDragEnd :: forall r i. (DragEvent -> Maybe i) -> IProp (onDragEnd :: DragEvent | r) i
+onDragEnd :: forall r i. (DragEvent -> i) -> IProp (onDragEnd :: DragEvent | r) i
 onDragEnd = handler DET.dragend <<< dragHandler
 
-onDragExit :: forall r i. (DragEvent -> Maybe i) -> IProp (onDragExit :: DragEvent | r) i
+onDragExit :: forall r i. (DragEvent -> i) -> IProp (onDragExit :: DragEvent | r) i
 onDragExit = handler DET.dragexit <<< dragHandler
 
-onDragEnter :: forall r i. (DragEvent -> Maybe i) -> IProp (onDragEnter :: DragEvent | r) i
+onDragEnter :: forall r i. (DragEvent -> i) -> IProp (onDragEnter :: DragEvent | r) i
 onDragEnter = handler DET.dragenter <<< dragHandler
 
-onDragLeave :: forall r i. (DragEvent -> Maybe i) -> IProp (onDragLeave :: DragEvent | r) i
+onDragLeave :: forall r i. (DragEvent -> i) -> IProp (onDragLeave :: DragEvent | r) i
 onDragLeave = handler DET.dragleave <<< dragHandler
 
-onDragOver :: forall r i. (DragEvent -> Maybe i) -> IProp (onDragOver :: DragEvent | r) i
+onDragOver :: forall r i. (DragEvent -> i) -> IProp (onDragOver :: DragEvent | r) i
 onDragOver = handler DET.dragover <<< dragHandler
 
-onDragStart :: forall r i. (DragEvent -> Maybe i) -> IProp (onDragStart :: DragEvent | r) i
+onDragStart :: forall r i. (DragEvent -> i) -> IProp (onDragStart :: DragEvent | r) i
 onDragStart = handler DET.dragstart <<< dragHandler
 
-onDrop :: forall r i. (DragEvent -> Maybe i) -> IProp (onDrop :: DragEvent | r) i
+onDrop :: forall r i. (DragEvent -> i) -> IProp (onDrop :: DragEvent | r) i
 onDrop = handler DET.drop <<< dragHandler
 
-onTouchCancel :: forall r i. (TouchEvent -> Maybe i) -> IProp (onTouchCancel :: TouchEvent | r) i
+onTouchCancel :: forall r i. (TouchEvent -> i) -> IProp (onTouchCancel :: TouchEvent | r) i
 onTouchCancel = handler (EventType "touchcancel") <<< touchHandler
 
-onTouchEnd :: forall r i. (TouchEvent -> Maybe i) -> IProp (onTouchEnd :: TouchEvent | r) i
+onTouchEnd :: forall r i. (TouchEvent -> i) -> IProp (onTouchEnd :: TouchEvent | r) i
 onTouchEnd = handler (EventType "touchend") <<< touchHandler
 
-onTouchEnter :: forall r i. (TouchEvent -> Maybe i) -> IProp (onTouchEnter :: TouchEvent | r) i
+onTouchEnter :: forall r i. (TouchEvent -> i) -> IProp (onTouchEnter :: TouchEvent | r) i
 onTouchEnter = handler (EventType "touchenter") <<< touchHandler
 
-onTouchLeave :: forall r i. (TouchEvent -> Maybe i) -> IProp (onTouchEnter :: TouchEvent | r) i
+onTouchLeave :: forall r i. (TouchEvent -> i) -> IProp (onTouchEnter :: TouchEvent | r) i
 onTouchLeave = handler (EventType "touchleave") <<< touchHandler
 
-onTouchMove :: forall r i. (TouchEvent -> Maybe i) -> IProp (onTouchMove :: TouchEvent | r) i
+onTouchMove :: forall r i. (TouchEvent -> i) -> IProp (onTouchMove :: TouchEvent | r) i
 onTouchMove = handler (EventType "touchmove") <<< touchHandler
 
-onTouchStart :: forall r i. (TouchEvent -> Maybe i) -> IProp (onTouchStart :: TouchEvent | r) i
+onTouchStart :: forall r i. (TouchEvent -> i) -> IProp (onTouchStart :: TouchEvent | r) i
 onTouchStart = handler (EventType "touchstart") <<< touchHandler
 
-onResize :: forall r i. (Event -> Maybe i) -> IProp (onResize :: Event | r) i
+onResize :: forall r i. (Event -> i) -> IProp (onResize :: Event | r) i
 onResize = handler (EventType "resize")
 
-keyHandler :: forall i. (KeyboardEvent -> Maybe i) -> Event -> Maybe i
+keyHandler :: forall i. (KeyboardEvent -> i) -> Event -> i
 keyHandler = unsafeCoerce
 
-mouseHandler :: forall i. (MouseEvent -> Maybe i) -> Event -> Maybe i
+mouseHandler :: forall i. (MouseEvent -> i) -> Event -> i
 mouseHandler = unsafeCoerce
 
-wheelHandler :: forall i. (WheelEvent -> Maybe i) -> Event -> Maybe i
+wheelHandler :: forall i. (WheelEvent -> i) -> Event -> i
 wheelHandler = unsafeCoerce
 
-focusHandler :: forall i. (FocusEvent -> Maybe i) -> Event -> Maybe i
+focusHandler :: forall i. (FocusEvent -> i) -> Event -> i
 focusHandler = unsafeCoerce
 
-dragHandler :: forall i. (DragEvent -> Maybe i) -> Event -> Maybe i
+dragHandler :: forall i. (DragEvent -> i) -> Event -> i
 dragHandler = unsafeCoerce
 
-clipboardHandler :: forall i. (ClipboardEvent -> Maybe i) -> Event -> Maybe i
+clipboardHandler :: forall i. (ClipboardEvent -> i) -> Event -> i
 clipboardHandler = unsafeCoerce
 
-touchHandler :: forall i. (TouchEvent -> Maybe i) -> Event -> Maybe i
+touchHandler :: forall i. (TouchEvent -> i) -> Event -> i
 touchHandler = unsafeCoerce
 
 -- | Attaches event handler to event `key` with getting `prop` field as an
 -- | argument of `handler`.
-addForeignPropHandler :: forall r i value. EventType -> String -> (Foreign -> F value) -> (value -> Maybe i) -> IProp r i
+addForeignPropHandler :: forall r i value. EventType -> String -> (Foreign -> F value) -> (value -> i) -> IProp r i
 addForeignPropHandler key prop reader f =
-  handler key $ EE.currentTarget >=> \e -> either (const Nothing) f $ runExcept $ go e
+  handler' key $ EE.currentTarget >=> \e -> either (const Nothing) (Just <<< f) $ runExcept $ go e
   where
   go a = reader <=< readProp prop $ unsafeToForeign a
 
 -- | Attaches an event handler which will produce an input when the value of an
 -- | input field changes.
-onValueChange :: forall r i. (String -> Maybe i) -> IProp (value :: String, onChange :: Event | r) i
+onValueChange :: forall r i. (String -> i) -> IProp (value :: String, onChange :: Event | r) i
 onValueChange = addForeignPropHandler ET.change "value" readString
 
 -- | Attaches an event handler which will produce an input when the seleced index of a
 -- | `select` element changes.
-onSelectedIndexChange :: forall r i. (Int -> Maybe i) -> IProp (selectedIndex :: Int, onChange :: Event | r) i
+onSelectedIndexChange :: forall r i. (Int -> i) -> IProp (selectedIndex :: Int, onChange :: Event | r) i
 onSelectedIndexChange = addForeignPropHandler ET.change "selectedIndex" readInt
 
 -- | Attaches an event handler which will fire on input.
-onValueInput :: forall r i. (String -> Maybe i) -> IProp (value :: String, onInput :: Event | r) i
+onValueInput :: forall r i. (String -> i) -> IProp (value :: String, onInput :: Event | r) i
 onValueInput = addForeignPropHandler ET.input "value" readString
 
 -- | Attaches an event handler which will fire when a checkbox is checked or
 -- | unchecked.
-onChecked :: forall r i. (Boolean -> Maybe i) -> IProp (checked :: Boolean, onChange :: Event | r) i
+onChecked :: forall r i. (Boolean -> i) -> IProp (checked :: Boolean, onChange :: Event | r) i
 onChecked = addForeignPropHandler ET.change "checked" readBoolean


### PR DESCRIPTION
In the ongoing idea to simplify things in Halogen 6, I've been thinking
a lot about doing this lately. I don't think I've ever used a `Nothing`
return in an event handler based on the value of the `Event`.

I have very occasionally had a listener that returned `Nothing` based on
the current component state, but there are two ways that can be handled
even after removing this: either omitting the listener in the prop
construction of the HTML (with `guard` or something), or just checking
the component state when handling the raised action instead.

Similarly the handler for `slot`ted child components - I do occasionally
use `const Nothing` as the handler when setting things up, but I've
sometimes been bitten by that by forgetting to go back and handle the
messages. If the component emits no message then `absurd` still works as
a handler in the absence of the `Maybe`.

So basically: I think this is more ergonomic for the vast majority of
use cases for handlers. For the rarer occurrences where filtering was
use, it's still possible to do that, just there's an extra step to deal
with.

I did also consider adding primed variants of everything, that still had
`Event -> Maybe i`, but despite my love of primed things, I figured
leaving them out entirely would probably be nicer from a new user
perspective :wink:

What do you think @natefaubion, @thomashoneyman, @JordanMartinez, @Benjmhart, or anyone else out there with an interest?