### PR TITLE
More comments describing parameters

### DIFF
--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -164,6 +164,20 @@ defaultEval =
   }
 
 -- | Accepts an `EvalSpec` to produce an `eval` function for a component.
+-- |
+-- | Examples:
+-- |
+-- |   H.mkEval
+-- |     { handleAction: const (pure unit)
+-- |     , handleQuery: const (pure Nothing)
+-- |     , receive: const Nothing
+-- |     , initialize: Nothing
+-- |     , finalize: Nothing
+-- |     }
+-- |
+-- |   H.mkEval H.defaultEval
+-- |
+-- |   H.mkEval (H.defaultEval { handleAction = ?handleAction })
 mkEval
   :: forall state query action slots input output m
    . EvalSpec state query action slots input output m

--- a/src/Halogen/Data/Slot.purs
+++ b/src/Halogen/Data/Slot.purs
@@ -23,6 +23,13 @@ import Unsafe.Coerce (unsafeCoerce)
 
 foreign import data Any :: Type
 
+-- | - `query` is the query algebra; the requests that can be made of the
+-- |   component
+-- | - `output` is the type of messages the component can raise
+-- | - `slot` is the type used to index the component by. Use `Unit` if
+-- |   there's only going to be one instance of that type of component,
+-- |   and some other type like `Int` or `String` if there are going to
+-- |   be multiple instances.
 data Slot (query :: Type -> Type) output slot
 
 newtype SlotStorage (slots :: # Type) (slot :: (Type -> Type) -> Type -> Type) =

--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -28,6 +28,11 @@ import Unsafe.Coerce (unsafeCoerce)
 
 -- | A convenience synonym for the output type of a `render` function, for a
 -- | component that renders HTML.
+-- |
+-- | - `action` is the type of actions; messages internal to the component that
+-- |   can be evaluated
+-- | - `slots` is the set of slots for addressing child components
+-- | - `m` is the effect monad used during evaluation
 type ComponentHTML action slots m = HTML (ComponentSlot HTML slots m action) action
 
 -- | A type useful for a chunk of HTML with no slot-embedding or query-raising.

--- a/src/Halogen/Query/HalogenM.purs
+++ b/src/Halogen/Query/HalogenM.purs
@@ -73,8 +73,8 @@ instance functorHalogenF :: Functor m => Functor (HalogenF state action slots ou
 -- | - `output` is the type of messages the component can raise
 -- | - `m` is the effect monad used during evaluation
 -- | - `a` is the result of the HalogenM expression. Use the following pattern:
--- |     `handleAction :: forall st ac sl o m. ac -> H.halogenM st ac sl o m Unit
--- |     `handleQuery  :: forall st ac sl o m a. YourQuery a -> H.halogenM st ac sl o m (Maybe a)
+-- |     `handleAction :: forall st ac sl o m.            ac -> H.HalogenM st ac sl o m Unit
+-- |     `handleQuery  :: forall st ac sl o m a. YourQuery a -> H.HalogenM st ac sl o m (Maybe a)
 newtype HalogenM state action slots output m a = HalogenM (Free (HalogenF state action slots output m) a)
 
 derive newtype instance functorHalogenM :: Functor (HalogenM state action slots output m)

--- a/src/Halogen/Query/HalogenM.purs
+++ b/src/Halogen/Query/HalogenM.purs
@@ -31,6 +31,14 @@ import Prim.Row as Row
 import Web.DOM (Element)
 
 -- | The Halogen component eval algebra.
+-- |
+-- | - `state` is the component's state
+-- | - `action` is the type of actions; messages internal to the component that
+-- |   can be evaluated
+-- | - `slots` is the set of slots for addressing child components
+-- | - `output` is the type of messages the component can raise
+-- | - `m` is the effect monad used during evaluation
+-- | - `a` is "an underlying value of unit". Just populate with `Unit` ?
 data HalogenF state action slots output m a
   = State (state -> Tuple a state)
   | Subscribe (SubscriptionId -> ES.EventSource m action) (SubscriptionId -> a)
@@ -57,6 +65,14 @@ instance functorHalogenF :: Functor m => Functor (HalogenF state action slots ou
     GetRef p k -> GetRef p (f <<< k)
 
 -- | The Halogen component eval effect monad.
+
+-- | - `state` is the component's state
+-- | - `action` is the type of actions; messages internal to the component that
+-- |   can be evaluated
+-- | - `slots` is the set of slots for addressing child components
+-- | - `output` is the type of messages the component can raise
+-- | - `m` is the effect monad used during evaluation
+-- | - `a` is "an underlying value of unit". Just populate with `Unit` ?
 newtype HalogenM state action slots output m a = HalogenM (Free (HalogenF state action slots output m) a)
 
 derive newtype instance functorHalogenM :: Functor (HalogenM state action slots output m)

--- a/src/Halogen/Query/HalogenM.purs
+++ b/src/Halogen/Query/HalogenM.purs
@@ -38,7 +38,7 @@ import Web.DOM (Element)
 -- | - `slots` is the set of slots for addressing child components
 -- | - `output` is the type of messages the component can raise
 -- | - `m` is the effect monad used during evaluation
--- | - `a` is "an underlying value of unit". Just populate with `Unit` ?
+-- | - `a` is the result of the HalogenF expression. See HalogenM for usage example.
 data HalogenF state action slots output m a
   = State (state -> Tuple a state)
   | Subscribe (SubscriptionId -> ES.EventSource m action) (SubscriptionId -> a)
@@ -65,14 +65,16 @@ instance functorHalogenF :: Functor m => Functor (HalogenF state action slots ou
     GetRef p k -> GetRef p (f <<< k)
 
 -- | The Halogen component eval effect monad.
-
+-- |
 -- | - `state` is the component's state
 -- | - `action` is the type of actions; messages internal to the component that
 -- |   can be evaluated
 -- | - `slots` is the set of slots for addressing child components
 -- | - `output` is the type of messages the component can raise
 -- | - `m` is the effect monad used during evaluation
--- | - `a` is "an underlying value of unit". Just populate with `Unit` ?
+-- | - `a` is the result of the HalogenM expression. Use the following pattern:
+-- |     `handleAction :: forall st ac sl o m. ac -> H.halogenM st ac sl o m Unit
+-- |     `handleQuery  :: forall st ac sl o m a. YourQuery a -> H.halogenM st ac sl o m (Maybe a)
 newtype HalogenM state action slots output m a = HalogenM (Free (HalogenF state action slots output m) a)
 
 derive newtype instance functorHalogenM :: Functor (HalogenM state action slots output m)


### PR DESCRIPTION
Filled in some missing documentation on parameters to make IDE tooltips more helpful for beginners.
Here's a screenshot of what things looked like before.

![halogenm_tooltip](https://user-images.githubusercontent.com/3578681/74214930-3518c100-4c54-11ea-9fe8-82139d9c6abc.png)

I'd like some feedback about what to put for the `a` parameter of `HalogenM`. I copied from [this part](https://github.com/purescript-halogen/purescript-halogen/blob/master/docs/2%20-%20Defining%20a%20component.md#evaluating-actions) of the guide.
```
`a` is "an underlying value of unit". Just populate with `Unit` ?
```