### PR TITLE
Update library to compile on 0.14.0 release

### DIFF
--- a/src/Halogen/Aff/Driver/State.purs
+++ b/src/Halogen/Aff/Driver/State.purs
@@ -69,11 +69,12 @@ newtype DriverStateRef h r f o = DriverStateRef (Ref (DriverStateX h r f o))
 
 -- | A version of `DriverState` with the aspects relating to child components
 -- | existentially hidden.
-data DriverStateX
-  (h :: Type -> Type -> Type)
-  (r :: Type -> Type -> # Type -> Type -> Type)
-  (f :: Type -> Type)
-  (o :: Type)
+foreign import data DriverStateX :: (Type -> Type -> Type) -> (Type -> Type -> Row Type -> Type -> Type) -> (Type -> Type) -> Type -> Type
+-- data DriverStateX
+--   (h :: Type -> Type -> Type)
+--   (r :: Type -> Type -> # Type -> Type -> Type)
+--   (f :: Type -> Type)
+--   (o :: Type)
 
 mkDriverStateXRef
   :: forall h r s f act ps i o
@@ -90,7 +91,8 @@ unDriverStateX = unsafeCoerce
 
 -- | A wrapper of `r` from `DriverState` with the aspects relating to child
 -- | components existentially hidden.
-data RenderStateX (r :: Type -> Type -> # Type -> Type -> Type)
+foreign import data RenderStateX :: (Type -> Type -> Row Type -> Type -> Type) -> Type
+-- data RenderStateX (r :: Type -> Type -> # Type -> Type -> Type)
 
 mkRenderStateX
   :: forall r s f ps o m

--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -182,11 +182,7 @@ mkEval args = case _ of
     unCoyoneda (\g → map (maybe (f unit) g) <<< args.handleQuery) req
 
 -- | A slot for a child component in a component's rendered content.
-data ComponentSlotBox
-  (surface :: Type -> Type -> Type)
-  (slots :: # Type)
-  (m :: Type -> Type)
-  (action :: Type)
+foreign import data ComponentSlotBox :: (Type -> Type -> Type) -> Row Type -> (Type -> Type) -> Type -> Type
 
 instance functorComponentSlotBox :: Functor (ComponentSlotBox surface slots m) where
   map f = unComponentSlot \slot ->

--- a/src/Halogen/Data/Slot.purs
+++ b/src/Halogen/Data/Slot.purs
@@ -25,7 +25,7 @@ foreign import data Any :: Type
 
 data Slot (query :: Type -> Type) output slot
 
-newtype SlotStorage (slots :: # Type) (slot :: (Type -> Type) -> Type -> Type) =
+newtype SlotStorage (slots :: Row Type) (slot :: (Type -> Type) -> Type -> Type) =
   SlotStorage (Map (Tuple String (OrdBox Any)) Any)
 
 empty :: forall slots slot. SlotStorage slots slot

--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -93,7 +93,7 @@ import Web.DOM.Element (Element)
 
 -- | The phantom row `r` can be thought of as a context which is synthesized in
 -- | the course of constructing a refined HTML expression.
-newtype IProp (r :: # Type) i = IProp (Prop (Input i))
+newtype IProp (r :: Row Type) i = IProp (Prop (Input i))
 
 derive instance newtypeIProp :: Newtype (IProp r i) _
 derive instance functorIProp :: Functor (IProp r)

--- a/src/Halogen/Query/ChildQuery.purs
+++ b/src/Halogen/Query/ChildQuery.purs
@@ -6,7 +6,7 @@ import Data.Maybe (Maybe)
 import Halogen.Data.Slot (SlotStorage)
 import Unsafe.Coerce (unsafeCoerce)
 
-data ChildQueryBox (ps :: # Type) a
+foreign import data ChildQueryBox :: Row Type -> Type -> Type
 
 data ChildQuery ps g o a f b =
   ChildQuery


### PR DESCRIPTION
Note: I'm not sure whether I converted every empty data declaration (e.g. `data Foo (a :: Type -> Type)` -> `foreign import data Foo :: (Type -> Type) -> Type`. `purs` didn't complain even when I hadn't gotten to some.^

^ At least I don't think it did.