### PR TITLE
Export lazy functions

### DIFF
--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -6,6 +6,9 @@ module Halogen.HTML
   , fromPlainHTML
   , slot
   , memoized
+  , lazy
+  , lazy2
+  , lazy3
   , module Halogen.HTML.Core
   , module Halogen.HTML.Elements
   , module Halogen.HTML.Properties


### PR DESCRIPTION
Currently the `lazy` functions aren't exported from the `Halogen.HTML` file. Perhaps I'm missing the proper way to use these, but it doesn't appear they can actually be used in user code without this change to the exports.