### PR TITLE
refactor: resolve partiality -> change ComponentSlotSpec input type

### DIFF
--- a/src/Halogen/Aff/Driver.purs
+++ b/src/Halogen/Aff/Driver.purs
@@ -239,14 +239,10 @@ runUI renderSpec component i = do
           dsx <- Ref.read existing
           unDriverStateX (\st -> do
             flip Ref.write st.handlerRef $ maybe (pure unit) handler <<< slot.output
-            handleAff $ Eval.evalM render st.selfRef (st.component.eval slot.input)) dsx
+            handleAff $ Eval.evalM render st.selfRef (st.component.eval (HQ.Receive slot.input unit))) dsx
           pure existing
         Nothing ->
-          case slot.input of
-            HQ.Receive si _ ->
-              runComponent lchs (maybe (pure unit) handler <<< slot.output) si slot.component
-            _ ->
-              throw "Halogen internal error: slot input was not a Receive query"
+          runComponent lchs (maybe (pure unit) handler <<< slot.output) slot.input slot.component
       isDuplicate <- isJust <<< slot.get <$> Ref.read childrenOutRef
       when isDuplicate
         $ warn "Halogen: Duplicate slot address was detected during rendering, unexpected results may occur"

--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -226,7 +226,7 @@ componentSlot label p comp input output =
     , pop: Slot.pop label p
     , set: Slot.insert label p
     , component: comp
-    , input: Receive input unit
+    , input: input
     , output
     }
 
@@ -236,7 +236,7 @@ type ComponentSlotSpec surface query input output slots m action =
   , pop :: forall slot. SlotStorage slots slot -> Maybe (Tuple (slot query output) (SlotStorage slots slot))
   , set :: forall slot. slot query output -> SlotStorage slots slot -> SlotStorage slots slot
   , component :: Component surface query input output m
-  , input :: forall a. HalogenQ query a input Unit
+  , input :: input
   , output :: output -> Maybe action
   }
 


### PR DESCRIPTION
the reason is that I was trying to write static renderer using https://github.com/purescript-halogen/purescript-halogen-vdom-string-renderer

without this change I would have to throw an error

```purs
renderComponent :: forall input query input output m . Halogen.Component Halogen.HTML.HTML query input output m -> input -> String
renderComponent component input = renderComponentImpl input component
  where
    renderComponentImpl :: forall query input output m . input -> Halogen.Component Halogen.HTML.HTML query input output m -> String
    renderComponentImpl input' = Halogen.unComponent (
      let
        renderComponentSpec :: forall state action slots . Halogen.Component.ComponentSpec Halogen.HTML.HTML state query action slots input output m -> String
        renderComponentSpec componentSpec =
          let
            (state :: state) = componentSpec.initialState input'
            (html :: Halogen.HTML.HTML (Halogen.ComponentSlot Halogen.HTML.HTML slots m action) action) = componentSpec.render state
            (vdom :: HalogenVDom.VDom (Array (HalogenVDom.Prop (Halogen.Query.Input action))) (Halogen.ComponentSlot Halogen.HTML.HTML slots m action)) = Newtype.unwrap html
          in HalogenVdomStringRenderer.DOM.render renderWidget vdom
      in renderComponentSpec
    )

    renderComponentSlotSpec :: forall query input output slots m action . Halogen.Component.ComponentSlotSpec Halogen.HTML.HTML query input output slots m action -> String
    renderComponentSlotSpec componentSlotSpec =
      case componentSlotSpec.input of
        Halogen.Query.HalogenQ.Receive input' _ ->
          renderComponentImpl input' componentSlotSpec.component
        _ ->
          -- Exception.throw "Halogen internal error: slot input was not a Receive query"
          "TODO: THROW ERROR HERE, make return `Either String String` instead of `String`"

    renderWidget :: forall slots m action . Halogen.ComponentSlot Halogen.HTML.HTML slots m action -> String
    renderWidget slot =
      case slot of
        Halogen.Component.ComponentSlot componentSlot ->
          Halogen.unComponentSlot renderComponentSlotSpec componentSlot
        Halogen.Component.ThunkSlot thunk ->
          let
            (html :: Halogen.HTML.HTML (Halogen.ComponentSlot Halogen.HTML.HTML slots m action) action) = HalogenVDom.runThunk thunk
            (vdom :: HalogenVDom.VDom (Array (HalogenVDom.Prop (Halogen.Query.Input action))) (Halogen.ComponentSlot Halogen.HTML.HTML slots m action)) = Newtype.unwrap html
           in HalogenVdomStringRenderer.DOM.render renderWidget vdom
```

but now I can write like this


```purs
....
    renderComponentSlotSpec :: forall query input output slots m action . Halogen.Component.ComponentSlotSpec Halogen.HTML.HTML query input output slots m action -> String
    renderComponentSlotSpec componentSlotSpec = renderComponentImpl componentSlotSpec.input componentSlotSpec.component

...
```