### PR TITLE
Remove use of Void from PlainHTML

### DIFF
--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -3,7 +3,6 @@
 module Halogen.HTML
   ( ComponentHTML
   , PlainHTML
-  , fromPlainHTML
   , slot
   , memoized
   , lazy
@@ -25,25 +24,19 @@ import Halogen.HTML.Core (class IsProp, AttrName(..), ClassName(..), HTML(..), N
 import Halogen.HTML.Core as Core
 import Halogen.HTML.Properties (IProp, attr, attrNS, prop)
 import Halogen.VDom.Thunk (thunk1, thunk2, thunk3, thunked)
-import Prelude (class Ord, Void)
+import Prelude (class Ord)
 import Prim.Row as Row
-import Unsafe.Coerce (unsafeCoerce)
 
 -- | A convenience synonym for the output type of a `render` function, for a
 -- | component that renders HTML.
 type ComponentHTML action slots m = HTML (ComponentSlot HTML slots m action) action
 
--- | A type useful for a chunk of HTML with no slot-embedding or query-raising.
+-- | A type useful for a chunk of HTML with no slot-embedding or action-raising.
 -- |
 -- | Often a polymorphic usage of `HTML` is good enough for this, but sometimes
--- | it's useful to have a type like this (and accompanying coercion) when doing
--- | things like creating components that accept a chunk of HTML as part of
--- | their configuration.
-type PlainHTML = HTML Void Void
-
--- | Relaxes the type of `PlainHTML` to make it compatible with all `HTML`.
-fromPlainHTML :: forall w i. PlainHTML -> HTML w i
-fromPlainHTML = unsafeCoerce -- ≅ bimap absurd absurd
+-- | it's useful to have a type like this when doing things like creating
+-- | components that accept a chunk of HTML as part of their configuration.
+type PlainHTML = forall w i. HTML w i
 
 -- | Defines a slot for a child component. Takes:
 -- | - the slot address label


### PR DESCRIPTION
The `PlainHTML` type can be used for HTML that doesn't have any widgets or actions:

```purs
module Halogen.HTML where

type PlainHTML = HTML Void Void
```

It can be used, for example, like this:

```purs
import Halogen.HTML as HH

element :: HH.PlainHTML
element = HH.text "Hello, world"
```

Unfortunately, if you try to use this with other HTML types, like in a component that does have actions, then you get an error:

```purs
-- ERROR: Cannot match type `Void` with type `Action`
render :: forall m. State -> H.ComponentHTML Action () m
render _ = HH.button [ HE.onClick \_ -> Just Toggle ] [ element ]
```

To solve this, there's a helper function called `fromPlainHTML`:

```purs
module Halogen.HTML where

fromPlainHTML :: forall w i. PlainHTML -> HTML w i
```

which can be used to fix our problem:

```purs
render _ = HH.button [ HE.onClick \_ -> Just Toggle ] [ HH.fromPlainHTML element ]
```

But this introduces extra ceremony around a useful type, `PlainHTML`, which could be avoided if we used an inner `forall` instead of `Void`:

```purs
type PlainHTML = forall w i. HTML w i
```

With this our plain HTML element looks identical, but we get to skip calls to fromPlainHTML later:

```purs
module Halogen.HTML where

element :: HH.PlainHTML
element = HH.text "Hello, world"

-- No longer an error: `element` is fine.
render :: forall m. State -> H.ComponentHTML Action () m
render _ = HH.button [ HE.onClick \_ -> Just Toggle ] [ element ]
```

This PR introduces this change, which includes removing the `fromPlainHTML` function. But if we'd prefer not to have a breaking change there we could also keep `fromPlainHTML` in place, though it would no longer be necessary.