### PR TITLE
aria-modal

### DIFF
--- a/src/Halogen/HTML/Properties/ARIA.purs
+++ b/src/Halogen/HTML/Properties/ARIA.purs
@@ -61,6 +61,9 @@ level = attr (AttrName "aria-level")
 live :: forall r i. String -> IProp r i
 live = attr (AttrName "aria-live")
 
+modal :: forall r i. String -> IProp r i
+modal = attr (AttrName "aria-modal")
+
 multiLine :: forall r i. String -> IProp r i
 multiLine = attr (AttrName "aria-multiline")
 


### PR DESCRIPTION
https://w3c.github.io/aria-practices/examples/dialog-modal/alertdialog.html#rps_label

>  Tells assistive technologies that the windows underneath the current alert dialog are not available for interaction (inert). 