### PR TITLE
Split queryF from query

### DIFF
--- a/src/Halogen/Query/HalogenM.purs
+++ b/src/Halogen/Query/HalogenM.purs
@@ -137,7 +137,19 @@ query
   -> slot
   -> query a
   -> HalogenM state action slots output m (Maybe a)
-query label p q = HalogenM $ liftF $ ChildQuery $ CQ.mkChildQueryBox $
+query label p q = HalogenM $ liftF $ queryF label p q
+
+-- | An alternative to `query` which does not wrap the HalogenF in free
+queryF
+  :: forall state action output m label slots query output' slot a _1
+   . Row.Cons label (Slot query output' slot) _1 slots
+  => IsSymbol label
+  => Ord slot
+  => SProxy label
+  -> slot
+  -> query a
+  -> HalogenF state action slots output m (Maybe a)
+queryF label p q = ChildQuery $ CQ.mkChildQueryBox $
   CQ.ChildQuery (\k → maybe (pure Nothing) k <<< Slot.lookup label p) q identity
 
 -- | Sends a query to all children of a component at a given slot label.


### PR DESCRIPTION
In [sigilion/purescript-run-halogen](https://github.com/sigilion/purescript-run-halogen) I find it useful to have a version of query that is not lifted into free, so that I can put the resulting HalogenF under VariantF in Run. I would prefer to have this split in the halogen source, rather than maintain my own version of query.