### PR TITLE
Add github link to mdbook

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,3 +5,4 @@ src = "docs"
 title = "Halogen Guide"
 [output.html]
 theme = "docs/theme"
+git-repository-url = "https://github.com/purescript-halogen/purescript-halogen"


### PR DESCRIPTION
Adds a button that links to the halogen repo in the upper right corner of each page.

![image](https://user-images.githubusercontent.com/3578681/98274781-b6358800-1f48-11eb-81d0-c4cfed0cf3d9.png)
