### PR TITLE
Replace `id_` with `id`

### DIFF
--- a/docs/guide/01-Rendering-Halogen-HTML.md
+++ b/docs/guide/01-Rendering-Halogen-HTML.md
@@ -65,7 +65,7 @@ You can see Halogen's emphasis on type safety displayed here.
 2. Only some values are possible for a button's `type` property, so Halogen restricts them with a sum type.
 3. CSS classes use a `ClassName` newtype so that they can be treated specially when needed; for example, the `classes` function ensures that your classes are space-separated when they're combined.
 
-Some HTML elements and properties clash with reserved keywords in PureScript or with common functions from the Prelude, so Halogen adds an underscore to them. That's why you see `type_` instead of `type` in the example above. (You also see `id_` instead of `id`, but in PureScript 0.12 the `id` function was renamed to `identity`; future versions of Halogen will just use `id` without an underscore.)
+Some HTML elements and properties clash with reserved keywords in PureScript or with common functions from the Prelude, so Halogen adds an underscore to them. That's why you see `type_` instead of `type` in the example above.
 
 When you don't need to set any properties on a Halogen HTML element, you can use its underscored version instead. For example, the `div` and `button` elements below have no properties:
 

--- a/docs/guide/01-Rendering-Halogen-HTML.md
+++ b/docs/guide/01-Rendering-Halogen-HTML.md
@@ -48,7 +48,7 @@ import Halogen.HTML.Properties as HP
 
 html =
   HH.div
-    [ HP.id_ "root" ]
+    [ HP.id "root" ]
     [ HH.input
         [ HP.placeholder "Name" ]
     , HH.button

--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -20,7 +20,7 @@ module Halogen.HTML.Properties
   , height
   , width
   , href
-  , id_
+  , id
   , name
   , rel
   , src
@@ -177,8 +177,8 @@ width = prop (PropName "width")
 href :: forall r i. String -> IProp (href :: String | r) i
 href = prop (PropName "href")
 
-id_ :: forall r i. String -> IProp (id :: String | r) i
-id_ = prop (PropName "id")
+id :: forall r i. String -> IProp (id :: String | r) i
+id = prop (PropName "id")
 
 name :: forall r i. String -> IProp (name :: String | r) i
 name = prop (PropName "name")

--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -21,6 +21,7 @@ module Halogen.HTML.Properties
   , width
   , href
   , id
+  , id_
   , name
   , rel
   , src
@@ -88,6 +89,7 @@ import Halogen.HTML.Core (class IsProp, AttrName(..), ClassName, Namespace, Prop
 import Halogen.HTML.Core as Core
 import Halogen.Query.Input (Input(..), RefLabel)
 import Prim.Row as Row
+import Prim.TypeError as TypeError
 import Unsafe.Coerce (unsafeCoerce)
 import Web.DOM.Element (Element)
 
@@ -179,6 +181,9 @@ href = prop (PropName "href")
 
 id :: forall r i. String -> IProp (id :: String | r) i
 id = prop (PropName "id")
+
+id_ :: forall r i. TypeError.Warn (TypeError.Text "`id_` is deprecated. Prefer `id` instead.") => String -> IProp (id :: String | r) i
+id_ = id
 
 name :: forall r i. String -> IProp (name :: String | r) i
 name = prop (PropName "name")


### PR DESCRIPTION
Hello maintainers.

I made this because I saw this comment on the guide:

https://github.com/purescript-halogen/purescript-halogen/blob/b0eee5db9081a86bcdadc6a515145e14b5e2d3ed/docs/guide/01-Rendering-Halogen-HTML.md#L68

but is this still too early?