### PR TITLE
Add scope property

### DIFF
--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -25,6 +25,7 @@ module Halogen.HTML.Properties
   , rel
   , src
   , style
+  , scope
   , target
   , title
   , download
@@ -80,6 +81,7 @@ import DOM.HTML.Indexed.MenuitemType (MenuitemType(..)) as I
 import DOM.HTML.Indexed.OnOff (OnOff(..)) as I
 import DOM.HTML.Indexed.OrderedListType (OrderedListType(..)) as I
 import DOM.HTML.Indexed.PreloadValue (PreloadValue(..)) as I
+import DOM.HTML.Indexed.ScopeValue(ScopeValue(..)) as I
 import DOM.HTML.Indexed.StepValue (StepValue(..)) as I
 import Data.Maybe (Maybe(..))
 import Data.MediaType (MediaType)
@@ -200,6 +202,9 @@ src = prop (PropName "src")
 -- | https://github.com/purescript-halogen/purescript-halogen-css
 style :: forall r i. String -> IProp (style :: String | r) i
 style = attr (AttrName "style")
+
+scope :: forall r i. I.ScopeValue -> IProp (scope :: I.ScopeValue | r) i
+scope = prop (PropName "scope")
 
 target :: forall r i. String -> IProp (target :: String | r) i
 target = prop (PropName "target")


### PR DESCRIPTION
The [halogen guide](https://github.com/purescript-halogen/purescript-halogen/blob/master/docs/guide/01-Rendering-Halogen-HTML.md) told me to add any property that's allowed but not in halogen yet.

So here I am, with nextto no knowledge of Purescript and Halogen creating this PR. Be gentle. :)