### PR TITLE
Update `onClick` to use the new type signature

### DIFF
--- a/docs/guide/02-Introducing-Components.md
+++ b/docs/guide/02-Introducing-Components.md
@@ -21,6 +21,7 @@ module Main where
 
 import Prelude
 
+import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -38,9 +39,9 @@ component =
 
   render state =
     HH.div_
-      [ HH.button [ HE.onClick \_ -> Decrement ] [ HH.text "-" ]
+      [ HH.button [ HE.onClick \_ -> Just Decrement ] [ HH.text "-" ]
       , HH.text (show state)
-      , HH.button [ HE.onClick \_ -> Increment ] [ HH.text "+" ]
+      , HH.button [ HE.onClick \_ -> Just Increment ] [ HH.text "+" ]
       ]
 
   handleAction = case _ of
@@ -172,9 +173,9 @@ import Halogen.HTML.Events
 render :: forall m. State -> H.ComponentHTML Action () m
 render state =
   HH.div_
-    [ HH.button [ HE.onClick \_ -> Decrement ] [ HH.text "-" ]
+    [ HH.button [ HE.onClick \_ -> Just Decrement ] [ HH.text "-" ]
     , HH.text (show state)
-    , HH.button [ HE.onClick \_ -> Increment ] [ HH.text "+" ]
+    , HH.button [ HE.onClick \_ -> Just Increment ] [ HH.text "+" ]
     ]
 ```
 
@@ -187,17 +188,17 @@ You might be curious about why we provided an anonymous function to `onClick`. T
 ```purs
 onClick
   :: forall row action
-   . (MouseEvent -> action)
+   . (MouseEvent -> Maybe action)
   -> IProp (onClick :: MouseEvent | row) action
 
 -- Specialized to our component
 onClick
   :: forall row
-   . (MouseEvent -> Action)
+   . (MouseEvent -> Maybe Action)
   -> IProp (onClick :: MouseEvent | row) Action
 ```
 
-In Halogen, event handlers take as their first argument a callback. This callback receives the DOM event that occurred (in the case of a click event, that's a `MouseEvent`), which contains some metadata you may want to use, and is then responsible for returning an action that Halogen should run in response to the event. In our case, we won't inspect the event itself, so we throw the argument away and return the action we want to run (`Increment` or `Decrement`).
+In Halogen, event handlers take as their first argument a callback. This callback receives the DOM event that occurred (in the case of a click event, that's a `MouseEvent`), which contains some metadata you may want to use, and is then responsible for returning an action that Halogen should run in response to the event (or `Nothing`, if no action should be performed). In our case, we won't inspect the event itself, so we throw the argument away and return the action we want to run (`Increment` or `Decrement`).
 
 The `onClick` function then returns a value of type `IProp`. You should remember `IProp` from the previous chapter. As a refresher, Halogen HTML elements specify a list of what properties and events they support. Properties and events in turn specify their type. Halogen is then able to ensure that you never use a property or event on an element that doesn't support it. In this case buttons do support `onClick` events, so we're good to go!
 
@@ -274,6 +275,7 @@ module Main where
 import Prelude
 
 import Effect (Effect)
+import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.Aff as HA
 import Halogen.HTML as HH
@@ -303,9 +305,9 @@ initialState _ = 0
 render :: forall m. State -> H.ComponentHTML Action () m
 render state =
   HH.div_
-    [ HH.button [ HE.onClick \_ -> Decrement ] [ HH.text "-" ]
+    [ HH.button [ HE.onClick \_ -> Just Decrement ] [ HH.text "-" ]
     , HH.text (show state)
-    , HH.button [ HE.onClick \_ -> Increment ] [ HH.text "+" ]
+    , HH.button [ HE.onClick \_ -> Just Increment ] [ HH.text "+" ]
     ]
 
 handleAction :: forall output m. Action -> H.HalogenM State Action () output m Unit

--- a/docs/guide/03-Performing-Effects.md
+++ b/docs/guide/03-Performing-Effects.md
@@ -104,7 +104,7 @@ render state = do
     , HH.p_
         [ HH.text ("Current value: " <> value) ]
     , HH.button
-        [ HE.onClick \_ -> Regenerate ]
+        [ HE.onClick \_ -> Just Regenerate ]
         [ HH.text "Generate new number" ]
     ]
 

--- a/docs/guide/04-Lifecycles-Subscriptions.md
+++ b/docs/guide/04-Lifecycles-Subscriptions.md
@@ -78,7 +78,7 @@ render state = do
     , HH.p_
         [ HH.text ("Current value: " <> value) ]
     , HH.button
-        [ HE.onClick \_ -> Regenerate ]
+        [ HE.onClick \_ -> Just Regenerate ]
         [ HH.text "Generate new number" ]
     ]
 

--- a/docs/guide/05-Parent-Child-Components.md
+++ b/docs/guide/05-Parent-Child-Components.md
@@ -345,7 +345,7 @@ button =
   where
   render _ =
     HH.button
-      [ HE.onClick \_ -> Click ]
+      [ HE.onClick \_ -> Just Click ]
       [ HH.text "Click me" ]
 
   -- Our output type also shows up in our `HalogenM` type, because this is
@@ -798,7 +798,7 @@ button =
   render :: ButtonState -> H.ComponentHTML ButtonAction () m
   render { label, enabled } =
     HH.button
-      [ HE.onClick \_ -> Click ]
+      [ HE.onClick \_ -> Just Click ]
       [ HH.text $ label <> " (" <> (if enabled then "on" else "off") <> ")" ]
 
   handleAction

--- a/docs/guide/06-Running-Application.md
+++ b/docs/guide/06-Running-Application.md
@@ -141,7 +141,7 @@ render state =
   in
     HH.button
       [ HP.title label
-      , HE.onClick \_ -> Toggle
+      , HE.onClick \_ -> Just Toggle
       ]
       [ HH.text label ]
 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -9,6 +9,7 @@ module Main where
 
 import Prelude
 
+import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Halogen as H
 import Halogen.Aff as HA
@@ -34,9 +35,9 @@ component =
 
   render state =
     HH.div_
-      [ HH.button [ HE.onClick \_ -> Decrement ] [ HH.text "-" ]
+      [ HH.button [ HE.onClick \_ -> Just Decrement ] [ HH.text "-" ]
       , HH.div_ [ HH.text $ show state ]
-      , HH.button [ HE.onClick \_ -> Increment ] [ HH.text "+" ]
+      , HH.button [ HE.onClick \_ -> Just Increment ] [ HH.text "+" ]
       ]
 
   handleAction = case _ of


### PR DESCRIPTION
Event handlers accept a function that returns a `Maybe`, according to the reference: https://pursuit.purescript.org/packages/purescript-halogen/5.0.0/docs/Halogen.HTML.Events#v:onClick

However, in the Halogen guide, the event handlers don't return a `Maybe`, so the example don't even compile. 
Maybe I'm missing something?