### PR TITLE
Docs: wrap onClick actions in a Maybe

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -9,6 +9,7 @@ module Main where
 
 import Prelude
 
+import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Halogen as H
 import Halogen.Aff as HA
@@ -34,9 +35,9 @@ component =
 
   render state =
     HH.div_
-      [ HH.button [ HE.onClick \_ -> Decrement ] [ HH.text "-" ]
+      [ HH.button [ HE.onClick \_ -> Just Decrement ] [ HH.text "-" ]
       , HH.div_ [ HH.text $ show state ]
-      , HH.button [ HE.onClick \_ -> Increment ] [ HH.text "+" ]
+      , HH.button [ HE.onClick \_ -> Just Increment ] [ HH.text "+" ]
       ]
 
   handleAction = case _ of


### PR DESCRIPTION
The [first example in the guide](https://purescript-halogen.github.io/purescript-halogen/guide/index.html) does not compile because the `onClick` actions have to be wrapped in a maybe.  It is quite possible that this is not the correct way to fix it, since I'm only just starting out with Halogen (hence why I encountered it :slightly_smiling_face:).