### PR TITLE
Use Halogen.Subscription instead of FRP.Event in guide 05

### DIFF
--- a/docs/guide/04-Lifecycles-Subscriptions.md
+++ b/docs/guide/04-Lifecycles-Subscriptions.md
@@ -261,9 +261,9 @@ handleAction = case _ of
 timer :: forall m a. MonadAff m => a -> m (HS.Emitter a)
 timer val = do
   { emitter, listener } <- H.liftEffect HS.create
-  _ <- Aff.forkAff $ forever do
+  _ <- H.liftAff $ Aff.forkAff $ forever do
     Aff.delay $ Milliseconds 1000.0
-    HS.notify listener val
+    H.liftEffect $ HS.notify listener val
   pure emitter
 ```
 
@@ -274,10 +274,10 @@ First, we've defined a reusable `Emitter` that will broadcast a value of our cho
 ```purs
 timer :: forall m a. MonadAff m => a -> m (HS.Emitter a)
 timer val = do
-  { emitter, listener } <- H.liftEffect Event.create
-  _ <- Aff.forkAff $ forever do
+  { emitter, listener } <- H.liftEffect HS.create
+  _ <- H.liftAff $ Aff.forkAff $ forever do
     Aff.delay $ Milliseconds 1000.0
-    HS.notify listener val
+    H.liftEffect $ HS.notify listener val
   pure emitter
 ```
 


### PR DESCRIPTION
The example code [here](https://purescript-halogen.github.io/purescript-halogen/guide/05-Parent-Child-Components.html#input) is using `FRP.Event` now. But considering that [purescript-event](https://github.com/paf31/purescript-event) is already archived and `spago install purescript-event` gives `the following packages do not exist` error, this PR migrates the code to `Halogen.Subscription` instead, which seems to be the recommended way of doing this in Halogen 6 as well.