### PR TITLE
Fix undefined type variable

### DIFF
--- a/docs/guide/05-Parent-Child-Components.md
+++ b/docs/guide/05-Parent-Child-Components.md
@@ -513,7 +513,7 @@ counter =
       [ HH.text $ show count ]
 
   -- We write a function to handle queries when they arise.
-  handleQuery :: forall action a. Query a -> H.HalogenM State action () o m (Maybe a)
+  handleQuery :: forall action a. Query a -> H.HalogenM State action () output m (Maybe a)
   handleQuery = case _ of
     -- When we receive the `Increment` query we'll increment our state.
     Increment a -> do


### PR DESCRIPTION
`output` is defined a few (13) lines earlier. 
As far as I can tell, `o` is never defined.