### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+**Description of the change**
+Clearly and concisely describe the purpose of the pull request. If this PR relates to an existing issue or change proposal, please link to it. Include any other background context that would help reviewers understand the motivation for this PR.
+
+---
+
+**Checklist:**
+
+- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
+- [ ] Linked any existing issues or proposals that this pull request should close
+- [ ] Updated or added relevant documentation in the README and/or documentation directory
+- [ ] Added a test for the contribution (if applicable)


### PR DESCRIPTION
This adds a pull request template matching the one used across the `core` and `contrib` organizations, reminding pull request authors of a few steps they should keep in mind (for example, linking issues to close, adding or updating documentation, and updating the changelog).