### PR TITLE
Add examples of lazy & memoized

### DIFF
--- a/examples/memoized-lazy/.gitignore
+++ b/examples/memoized-lazy/.gitignore
@@ -1,0 +1,1 @@
+/dist/example.js

--- a/examples/memoized-lazy/README.md
+++ b/examples/memoized-lazy/README.md
@@ -1,0 +1,14 @@
+# Improving Performance With Laziness
+
+This example demonstrates how to improve performance by skipping expensive functions in rendering when their arguments are unchanged.
+
+## Building
+
+You can build this example from the root of the Halogen project:
+
+```sh
+npm install
+npm run example-memoized-lazy
+```
+
+This will bundle a runnable JS file, `example.js`, in the `examples/memoized-lazy/dist` directory. You can view the running application by opening the corresponding `index.html` file.

--- a/examples/memoized-lazy/dist/index.html
+++ b/examples/memoized-lazy/dist/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Halogen Example - Memoized &amp; Lazy</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        max-width: 800px;
+        margin: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <script src="example.js"></script>
+  </body>
+</html>

--- a/examples/memoized-lazy/spago.dhall
+++ b/examples/memoized-lazy/spago.dhall
@@ -1,0 +1,6 @@
+let config = ../../spago.dhall
+
+in config // {
+  sources = config.sources # [ "examples/memoized-lazy/**/*.purs" ],
+  dependencies = config.dependencies
+}

--- a/examples/memoized-lazy/src/Component.purs
+++ b/examples/memoized-lazy/src/Component.purs
@@ -1,0 +1,105 @@
+module Example.MemoizedLazy.Component where
+
+import Prelude
+
+import Data.Const (Const)
+import Data.Maybe (Maybe(..))
+import Example.MemoizedLazy.Fibonnaci (renderFib)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML as HP
+import Halogen.HTML.Events as HE
+
+type Slot p = H.Slot (Const Void) Void p
+
+type Input = { fibInt :: Int }
+
+type State = { color :: String, fibInt :: Int }
+
+data Action = ToggleColor | HandleInput Input
+
+color1 = "antiquewhite" :: String
+color2 = "darkseagreen" :: String
+
+normalComponent :: forall q o m. H.Component q Input o m
+normalComponent =
+  H.mkComponent
+    { initialState
+    , render: HH.memoized eq render
+    , eval: H.mkEval $ H.defaultEval
+        { handleAction = handleAction
+        , receive = Just <<< HandleInput
+        }
+    }
+  where
+  render state =
+    HH.p
+      [ colorStyle state ]
+      [ HH.p_ [ HH.text "I am not using 'memoized' or 'lazy', so I am slow." ]
+      , HH.p_ [ HH.strong_ [ renderFib state.fibInt ] ]
+      , toggleButton
+      ]
+
+memoizedComponent :: forall q o m. H.Component q Input o m
+memoizedComponent =
+  H.mkComponent
+    { initialState
+    , render
+    , eval: H.mkEval $ H.defaultEval
+        { handleAction = handleAction
+        , receive = Just <<< HandleInput
+        }
+    }
+  where
+  renderFibMemoized = HH.memoized eq renderFib
+
+  render state = do
+    HH.p
+      [ colorStyle state ]
+      [ HH.p_ [ HH.text "I am using 'memoized' on 'renderFib' using an 'eq' comparison." ]
+      , HH.p_ [ HH.strong_ [ renderFibMemoized state.fibInt ] ]
+      , toggleButton
+      ]
+
+lazyComponent :: forall q o m. H.Component q Input o m
+lazyComponent =
+  H.mkComponent
+    { initialState
+    , render
+    , eval: H.mkEval $ H.defaultEval
+        { handleAction = handleAction
+        , receive = Just <<< HandleInput
+        }
+    }
+  where
+  render state =
+    HH.p
+      [ colorStyle state ]
+      [ HH.p_ [ HH.text "I am using 'lazy' on 'renderFib', which uses reference equality." ]
+      , HH.p_ [ HH.strong_ [ HH.lazy renderFib state.fibInt ] ]
+      , toggleButton
+      ]
+
+toggleButton :: forall w. HH.HTML w Action
+toggleButton =
+  HH.button
+    [ HE.onClick \_ -> ToggleColor ]
+    [ HH.text "Toggle" ]
+
+colorStyle :: forall r i. State -> HH.IProp r i
+colorStyle state =
+  HP.attr (HH.AttrName "style") ("background-color: " <> state.color <> ";")
+
+initialState :: Input -> State
+initialState { fibInt } = { fibInt, color: color1 }
+
+handleAction :: forall o m. Action -> H.HalogenM State Action () o m Unit
+handleAction = case _ of
+  HandleInput { fibInt } ->
+    H.modify_ _ { fibInt = fibInt }
+  ToggleColor -> do
+    { color } <- H.get
+    if color == color1 then
+      H.modify_ _ { color = color2 }
+    else
+      H.modify_ _ { color = color1 }

--- a/examples/memoized-lazy/src/Component.purs
+++ b/examples/memoized-lazy/src/Component.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Data.Const (Const)
 import Data.Maybe (Maybe(..))
-import Example.MemoizedLazy.Fibonnaci (renderFib)
+import Example.MemoizedLazy.Fibonacci (renderFib)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML as HP

--- a/examples/memoized-lazy/src/Component.purs
+++ b/examples/memoized-lazy/src/Component.purs
@@ -25,7 +25,7 @@ normalComponent :: forall q o m. H.Component q Input o m
 normalComponent =
   H.mkComponent
     { initialState
-    , render: HH.memoized eq render
+    , render
     , eval: H.mkEval $ H.defaultEval
         { handleAction = handleAction
         , receive = Just <<< HandleInput

--- a/examples/memoized-lazy/src/Container.purs
+++ b/examples/memoized-lazy/src/Container.purs
@@ -33,7 +33,7 @@ render :: forall m. State -> H.ComponentHTML Action ChildSlots m
 render state =
   HH.div_
     [ HH.p_
-        [ HH.text "Make the Fibonnaci function slower. Currently: "
+        [ HH.text "Make the Fibonacci function slower. Currently: "
         , HH.strong_ [ HH.text (show state.fibInt) ]
         , HH.button
             [ HE.onClick \_ -> Add 1 ]

--- a/examples/memoized-lazy/src/Container.purs
+++ b/examples/memoized-lazy/src/Container.purs
@@ -1,0 +1,58 @@
+module Example.MemoizedLazy.Container where
+
+import Prelude
+
+import Example.MemoizedLazy.Component as Component
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Type.Proxy (Proxy(..))
+
+data Action = Add Int
+
+type State = { fibInt :: Int }
+
+type ChildSlots =
+  ( memoizedLazy :: Component.Slot Int
+  )
+
+_memoizedLazy = Proxy :: Proxy "memoizedLazy"
+
+component :: forall q i o m. H.Component q i o m
+component =
+  H.mkComponent
+    { initialState
+    , render
+    , eval: H.mkEval $ H.defaultEval { handleAction = handleAction }
+    }
+
+initialState :: forall i. i -> State
+initialState _ = { fibInt: 30 }
+
+render :: forall m. State -> H.ComponentHTML Action ChildSlots m
+render state =
+  HH.div_
+    [ HH.p_
+        [ HH.text "Make the Fibonnaci function slower. Currently: "
+        , HH.strong_ [ HH.text (show state.fibInt) ]
+        , HH.button
+            [ HE.onClick \_ -> Add 1 ]
+            [ HH.text "Add 1" ]
+        , HH.button
+            [ HE.onClick \_ -> Add 3 ]
+            [ HH.text "Add 3" ]
+        , HH.button
+            [ HE.onClick \_ -> Add 7 ]
+            [ HH.text "Add 7" ]
+        ]
+    , HH.ul_
+        [ HH.slot_ _memoizedLazy 1 Component.normalComponent state
+        , HH.slot_ _memoizedLazy 2 Component.memoizedComponent state
+        , HH.slot_ _memoizedLazy 3 Component.lazyComponent state
+        ]
+    ]
+
+handleAction :: forall o m. Action -> H.HalogenM State Action ChildSlots o m Unit
+handleAction = case _ of
+  Add n ->
+    H.modify_ \state -> state { fibInt = state.fibInt + n }

--- a/examples/memoized-lazy/src/Fibonacci.purs
+++ b/examples/memoized-lazy/src/Fibonacci.purs
@@ -1,18 +1,18 @@
 -- | This module implements an extremely slow fibonacci function, which can be
 -- | used to observe the improvement provided by the `memoized` and `lazy`
 -- | functions in render code.
-module Example.MemoizedLazy.Fibonnaci where
+module Example.MemoizedLazy.Fibonacci where
 
 import Prelude
 
 import Data.Array (fold)
 import Halogen.HTML as HH
 
--- | Render the number at the given position in the Fibonnaci sequence.
+-- | Render the number at the given position in the Fibonacci sequence.
 renderFib :: forall w i. Int -> HH.HTML w i
 renderFib n =
   HH.text $ fold
-    [ "The Fibonnaci number for "
+    [ "The Fibonacci number for "
     , show n
     , " is "
     , show $ fib n

--- a/examples/memoized-lazy/src/Fibonnaci.purs
+++ b/examples/memoized-lazy/src/Fibonnaci.purs
@@ -1,0 +1,26 @@
+-- | This module implements an extremely slow fibonacci function, which can be
+-- | used to observe the improvement provided by the `memoized` and `lazy`
+-- | functions in render code.
+module Example.MemoizedLazy.Fibonnaci where
+
+import Prelude
+
+import Data.Array (fold)
+import Halogen.HTML as HH
+
+-- | Render the number at the given position in the Fibonnaci sequence.
+renderFib :: forall w i. Int -> HH.HTML w i
+renderFib n =
+  HH.text $ fold
+    [ "The Fibonnaci number for "
+    , show n
+    , " is "
+    , show $ fib n
+    , "."
+    ]
+
+-- | An extremely slow implementation of the Fibonacci function.
+fib :: Int -> Int
+fib 1 = 1
+fib 0 = 0
+fib n = fib (n - 1) + fib (n - 2)

--- a/examples/memoized-lazy/src/Main.purs
+++ b/examples/memoized-lazy/src/Main.purs
@@ -1,0 +1,13 @@
+module Example.MemoizedLazy.Main where
+
+import Prelude
+
+import Effect (Effect)
+import Example.MemoizedLazy.Container as Container
+import Halogen.Aff as HA
+import Halogen.VDom.Driver (runUI)
+
+main :: Effect Unit
+main = HA.runHalogenAff do
+  body <- HA.awaitBody
+  runUI Container.component unit body

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "example-higher-order-components": "spago --config examples/higher-order-components/spago.dhall bundle-app --main Example.HOC.Main --to examples/higher-order-components/dist/example.js",
     "example-interpret": "spago --config examples/interpret/spago.dhall bundle-app --main Example.Interpret.Main --to examples/interpret/dist/example.js",
     "example-keyboard-input": "spago --config examples/keyboard-input/spago.dhall bundle-app --main Example.KeyboardInput.Main --to examples/keyboard-input/dist/example.js",
-    "example-lifecycle": "spago --config examples/lifecycle/spago.dhall bundle-app --main Example.Lifecycle.Main --to examples/lifecycle/dist/example.js"
+    "example-lifecycle": "spago --config examples/lifecycle/spago.dhall bundle-app --main Example.Lifecycle.Main --to examples/lifecycle/dist/example.js",
+    "example-memoized-lazy": "spago --config examples/memoized-lazy/spago.dhall bundle-app --main Example.MemoizedLazy.Main --to examples/memoized-lazy/dist/example.js"
   },
   "devDependencies": {
     "purescript-psa": "^0.8.2",

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,17 +1,4 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210304/packages.dhall sha256:c88151fe7c05f05290224c9c1ae4a22905060424fb01071b691d3fe2e5bad4ca
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210409/packages.dhall sha256:e81c2f2ce790c0e0d79869d22f7a37d16caeb5bd81cfda71d46c58f6199fd33f
 
 in  upstream
-  with halogen-subscriptions =
-    { version = "main"
-    , repo = "https://github.com/purescript-halogen/purescript-halogen-subscriptions"
-    , dependencies =
-        [ "arrays"
-        , "effect"
-        , "foldable-traversable"
-        , "functors"
-        , "refs"
-        , "safe-coerce"
-        , "unsafe-reference"
-        ]
-    }


### PR DESCRIPTION
This PR adds examples for the `lazy` and `memoized` functions. The example works by displaying three results of calling a very poor fibonnaci implementation, with an extra button to toggle the background color of the example. Toggling the background color without memoization leads to extremely slow renders.

The first example re-renders any time the state changes, like normal Halogen, and it's quite slow. The second example uses `memoized` with `eq`, and it's quite slow because of #742 (but is fixed in #743). The third example uses `lazy` and is quite fast.

Here's a demonstration of this example running against `master`:

https://user-images.githubusercontent.com/10245104/114250335-39249980-9952-11eb-80bf-b73231d18e5b.mov

Notably, the `memoized` example is still very slow. But if I run this example against the `fix-memoized` branch used in #743 the result is what we'd expect:

https://user-images.githubusercontent.com/10245104/114250355-493c7900-9952-11eb-8c2b-a3b337af8cac.mov
