### PR TITLE
Fixing error in the guide: requestAll function is in Halogen.Query.

### DIFF
--- a/docs/guide/05-Parent-Child-Components.md
+++ b/docs/guide/05-Parent-Child-Components.md
@@ -667,6 +667,7 @@ import Effect (Effect)
 import Effect.Class (class MonadEffect)
 import Effect.Class.Console (logShow)
 import Halogen as H
+import Halogen.Query as HQ
 import Halogen.Aff as HA
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -735,7 +736,7 @@ parent =
         -- enabled state, which we log to the console.
         H.modify_ \state -> state { clicked = state.clicked + 1 }
         H.tell _button 0 (SetEnabled true)
-        on <- H.requestAll _button GetEnabled
+        on <- HQ.requestAll _button GetEnabled
         logShow on
 
 -- We now move on to the child component, a component called `button`.


### PR DESCRIPTION
As explained in [Issue 759](https://github.com/purescript-halogen/purescript-halogen/issues/759), the example in the guide was wrong: `requestAll` was failing.

I found out that `requestAll` actually is a function in `Halogen.Query`and not directly in `Halogen`.

I tried this version, this now works in `Try Purescript`.