### PR TITLE
Add onBeforeInput property

### DIFF
--- a/src/Halogen/HTML/Events.purs
+++ b/src/Halogen/HTML/Events.purs
@@ -98,6 +98,7 @@ import Web.UIEvent.KeyboardEvent (KeyboardEvent)
 import Web.UIEvent.KeyboardEvent.EventTypes as KET
 import Web.UIEvent.MouseEvent (MouseEvent)
 import Web.UIEvent.MouseEvent.EventTypes as MET
+import Web.UIEvent.InputEvent.EventTypes as IET
 import Web.PointerEvent (PointerEvent)
 import Web.PointerEvent.EventTypes as PET
 import Web.UIEvent.WheelEvent (WheelEvent)
@@ -151,7 +152,7 @@ onInput :: forall r i. (Event -> i) -> IProp (onInput :: Event | r) i
 onInput = handler ET.input
 
 onBeforeInput :: forall r i. (Event -> i) -> IProp (onBeforeInput :: Event | r) i
-onBeforeInput = handler ET.input
+onBeforeInput = handler IET.beforeinput
 
 onInvalid :: forall r i. (Event -> i) -> IProp (onInvalid :: Event | r) i
 onInvalid = handler ET.invalid

--- a/src/Halogen/HTML/Events.purs
+++ b/src/Halogen/HTML/Events.purs
@@ -8,6 +8,7 @@ module Halogen.HTML.Events
   , onChange
   , onFileUpload
   , onInput
+  , onBeforeInput
   , onInvalid
   , onReset
   , onSelect
@@ -148,6 +149,9 @@ onFileUpload f = handler ET.change $
 
 onInput :: forall r i. (Event -> i) -> IProp (onInput :: Event | r) i
 onInput = handler ET.input
+
+onBeforeInput :: forall r i. (Event -> i) -> IProp (onBeforeInput :: Event | r) i
+onBeforeInput = handler ET.input
 
 onInvalid :: forall r i. (Event -> i) -> IProp (onInvalid :: Event | r) i
 onInvalid = handler ET.invalid


### PR DESCRIPTION
This adds a property "onBeforeInput" to react to [beforeinput](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event) events.

~~Currently blocked by https://github.com/purescript-halogen/purescript-dom-indexed/pull/32~~