### PR TITLE
Add roles

### DIFF
--- a/src/Halogen/Aff/Driver/State.purs
+++ b/src/Halogen/Aff/Driver/State.purs
@@ -74,6 +74,8 @@ data DriverStateX
   (f :: Type -> Type)
   (o :: Type)
 
+type role DriverStateX representational representational representational
+
 mkDriverStateXRef
   :: forall r s f act ps i o
    . Ref (DriverState r s f act ps i o)

--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -52,6 +52,8 @@ data Component
   (output :: Type)
   (m :: Type -> Type)
 
+type role Component representational representational representational representational
+
 -- | The spec for a component.
 -- |
 -- | The type variables involved:
@@ -196,6 +198,8 @@ data ComponentSlotBox
   (slots :: Row Type)
   (m :: Type -> Type)
   (action :: Type)
+
+type role ComponentSlotBox representational representational representational
 
 instance functorComponentSlotBox :: Functor (ComponentSlotBox slots m) where
   map f = unComponentSlot \slot ->

--- a/src/Halogen/Data/Slot.purs
+++ b/src/Halogen/Data/Slot.purs
@@ -45,6 +45,8 @@ foreign import data Any :: Type
 data Slot :: (Type -> Type) -> Type -> Type -> Type
 data Slot (query :: Type -> Type) output slot
 
+type role Slot representational representational representational
+
 newtype SlotStorage (slots :: Row Type) (slot :: (Type -> Type) -> Type -> Type) =
   SlotStorage (Map (Tuple String (OrdBox Any)) Any)
 


### PR DESCRIPTION
Resolves #823

The other way to resolve this would be to use `foreign import data` rather than nullary `data`, but the disadvantage of that is there's no way to name the type parameters for documentation purposes.